### PR TITLE
add pathspec, run tests, more metadata, lint recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,15 @@ About yamllint
 
 Home: https://github.com/adrienverge/yamllint
 
-Package license: GPLv3
+Package license: GPL-3.0-only
 
 Feedstock license: BSD 3-Clause
 
 Summary: A linter for YAML files.
 
+yamllint does not only check for syntax validity, but for weirdnesses like
+key repetition and cosmetic problems such as lines length, trailing spaces,
+indentation, etc.
 
 
 Current build status
@@ -113,5 +116,6 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@bollwyvl](https://github.com/bollwyvl/)
 * [@proinsias](https://github.com/proinsias/)
 

--- a/recipe/.yamllint
+++ b/recipe/.yamllint
@@ -1,0 +1,3 @@
+---
+rules:
+  document-start: disable

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,44 +1,56 @@
-{% set name = "yamllint" %}
-{% set version = "1.15.0" %}
-{% set sha256 = "8f25759997acb42e52b96bf3af0b4b942e6516b51198bebd3402640102006af7" %}
-
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+  name: '{% set name = "yamllint" %}{{ name }}'
+  version: '{% set version = "1.15.0" %}{{ version }}'
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
+  # yamllint disable-line rule:line-length
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: 8f25759997acb42e52b96bf3af0b4b942e6516b51198bebd3402640102006af7
 
 build:
   noarch: python
-  number: 0
-  script: python -m pip install --no-deps --ignore-installed .
+  number: 1
+  script: "{{ PYTHON }} -m pip install --no-deps --ignore-installed ."
+  entry_points:
+    - yamllint=yamllint.cli:run
 
 requirements:
   host:
     - pip
     - python
-    - setuptools
   run:
+    - pathspec
     - python
     - pyyaml
 
 test:
+  source_files:
+    - tests
+  requires:
+    - pytest
   imports:
     - yamllint
-  requires:
-    - nose
+  commands:
+    - python -m pytest .  # [unix]
+    - yamllint --help
+    - yamllint --version
+    - cd {{ RECIPE_DIR }} && yamllint --strict --format parsable .
 
 about:
   home: https://github.com/adrienverge/yamllint
-  license: GPLv3
+  license: GPL-3.0-only
+  license_family: GPL
   license_file: LICENSE
   summary: 'A linter for YAML files.'
-  doc_url: https://yamllint.readthedocs.io/
-  dev_url: https://github.com/adrienverge/yamllint
+  doc_url: https://yamllint.readthedocs.io
+  doc_source_url: |
+    https://github.com/adrienverge/yamllint/blob/master/docs/index.rst
+  description: |
+    yamllint does not only check for syntax validity, but for weirdnesses like
+    key repetition and cosmetic problems such as lines length, trailing spaces,
+    indentation, etc.
 
 extra:
   recipe-maintainers:
     - proinsias
+    - bollwyvl


### PR DESCRIPTION
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Thanks for maintaining this package! 

This presumably supersedes #12 and #6, and fixes #5.

I've made a few normal changes to the recipe:
- myself as a maintainer, 
  - I'll likely be using it a fair amount, and have increased the complexity (but also hopefully the utility!) of the recipe by a fair amount.
  - add `entry_points`
  - run the tests
  - description
  - license family
  - license SPDX
  - removed some redundant dependency 
  - add/remove some jinja variables

.. as well as a few unorthodox ones for the purposes of dogfooding `yamllint` on the recipe itself.
  - `set`ting name/version right in their first usage means they don't break yamllint

I verified these changes on linux and windows: the upstream tests don't even import on windows (`fcntl`) and are littered with hard-coded `/` paths, so I've skipped them for now (not _really_ relevant for `noarch: python`, but I end up having to re-arch a lot of them for `constructor`ing, and like to be thorough).

No doubt i ironically missed something in changing/linting/rerendering, but should be ready for review!