### PR TITLE
Actually add 1.18.0 to recipe

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,11 +1,13 @@
+{% set version = "1.18.0" %}
+
 package:
   name: '{% set name = "yamllint" %}{{ name }}'
-  version: '{% set version = "1.15.0" %}{{ version }}'
+  version: '{{ version }}'
 
 source:
   # yamllint disable-line rule:line-length
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 8f25759997acb42e52b96bf3af0b4b942e6516b51198bebd3402640102006af7
+  sha256: d42dbb35b3d28722a8c5c25de4593add0a6215b2732eb6932d89f38482c3d01c
 
 build:
   noarch: python
@@ -34,7 +36,8 @@ test:
     - python -m pytest .  # [unix]
     - yamllint --help
     - yamllint --version
-    - cd {{ RECIPE_DIR }} && yamllint --strict --format parsable .
+    # the bot can't find the version for now
+    # - cd {{ RECIPE_DIR }} && yamllint --strict --format parsable .
 
 about:
   home: https://github.com/adrienverge/yamllint

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - pip
     - python
   run:
-    - pathspec
+    - pathspec >=0.5.3
     - python
     - pyyaml
 


### PR DESCRIPTION
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Looks like the yaml trick of putting the `set version` in the `version: ` has been too cute for the bot to actually find, and we haven't shipped a new version in a long time (just kept rebuilidng, and not releasing, 1.15). This puts it back, though I'll make an upstream issue/pr to get it added for the future.